### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish_nighty.yml
+++ b/.github/workflows/publish_nighty.yml
@@ -18,7 +18,7 @@ jobs:
       id: date
       run: echo "::set-output name=date::$(date +'%Y-%m-%d %H:%M:%S %z')"
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         REPLACE_CHINA_MIRROR: false
         VCS_REF: ${{ github.sha }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -16,7 +16,7 @@ jobs:
       id: version
       run: echo ::set-output name=tag::$(echo ${GITHUB_REF:10})
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         REPLACE_CHINA_MIRROR: false
         VCS_REF: ${{ github.sha }}

--- a/.github/workflows/test_docker_build.yml
+++ b/.github/workflows/test_docker_build.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Build the Docker image
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         REPLACE_CHINA_MIRROR: false
         VCS_REF: ${{ github.sha }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore